### PR TITLE
Quick sso

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 # rspec failure tracking
 .rspec_status
+.byebug_history

--- a/aker_credentials_gem.gemspec
+++ b/aker_credentials_gem.gemspec
@@ -31,8 +31,14 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "jwt"
   spec.add_dependency "request_store"
+  spec.add_dependency 'activemodel'
+  spec.add_dependency 'activesupport'
+  spec.add_dependency 'faraday'
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "pry-byebug"
+  spec.add_development_dependency "rails"
+
 end

--- a/aker_credentials_gem.gemspec
+++ b/aker_credentials_gem.gemspec
@@ -31,14 +31,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "jwt"
   spec.add_dependency "request_store"
-  spec.add_dependency 'activemodel'
-  spec.add_dependency 'activesupport'
   spec.add_dependency 'faraday'
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry-byebug"
-  spec.add_development_dependency "rails"
 
 end

--- a/lib/aker_credentials_gem/version.rb
+++ b/lib/aker_credentials_gem/version.rb
@@ -1,3 +1,3 @@
 module AkerCredentialsGem
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/lib/aker_credentials_gem/version.rb
+++ b/lib/aker_credentials_gem/version.rb
@@ -1,3 +1,3 @@
 module AkerCredentialsGem
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/lib/aker_credentials_gem/version.rb
+++ b/lib/aker_credentials_gem/version.rb
@@ -1,3 +1,3 @@
 module AkerCredentialsGem
-  VERSION = "0.1.3"
+  VERSION = "0.2.0"
 end

--- a/lib/aker_credentials_gem/version.rb
+++ b/lib/aker_credentials_gem/version.rb
@@ -1,3 +1,3 @@
 module AkerCredentialsGem
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/lib/jwt_credentials.rb
+++ b/lib/jwt_credentials.rb
@@ -47,6 +47,8 @@ module JWTCredentials
       rescue JWT::ExpiredSignature => e
         render body: nil, status: :unauthorized
       end
+    elsif Rails.configuration.respond_to? :default_jwt_user
+      build_user(Rails.configuration.default_jwt_user)
     else
       build_user("email" => 'guest', "groups" => ['world'])
     end

--- a/lib/jwt_credentials.rb
+++ b/lib/jwt_credentials.rb
@@ -49,8 +49,10 @@ module JWTCredentials
       end
     elsif Rails.configuration.respond_to? :default_jwt_user
       build_user(Rails.configuration.default_jwt_user)
-    else
-      build_user("email" => 'guest', "groups" => ['world'])
     end
-  end  
+  end
+
+  def jwt_provided?
+    x_auth_user.present?
+  end
 end

--- a/lib/jwt_credentials.rb
+++ b/lib/jwt_credentials.rb
@@ -12,40 +12,39 @@ module JWTCredentials
   end
 
   def apply_credentials
-    if current_user
-      session['user'] = current_user
-    end
-    RequestStore.store[:x_authorisation] = session['user']
+    RequestStore.store[:x_authorisation] = current_user
   end
 
-  def build_user_session(hash)
+  def build_user(hash)
     if defined? User
-      session['user'] = User.from_jwt_data(hash)
+      @x_auth_user = User.from_jwt_data(hash)
     else
-      session['user'] = OpenStruct.new(hash)
-    end    
+      @x_auth_user = OpenStruct.new(hash)
+    end
+  end
+
+  # Override this for cases where the user credentials come from elsewhere,
+  #  e.g. a login session
+  def current_user
+    @x_auth_user
   end
 
   def check_credentials
+    @x_auth_user = nil
     if request.headers.to_h['HTTP_X_AUTHORISATION']
       begin
         secret_key = Rails.configuration.jwt_secret_key
         token = request.headers.to_h['HTTP_X_AUTHORISATION']
         payload, header = JWT.decode token, secret_key, true, { algorithm: 'HS256'}
         ud = payload["data"]
-        build_user_session(ud)
-
+        build_user(ud)
       rescue JWT::VerificationError => e
         render body: nil, status: :unauthorized
       rescue JWT::ExpiredSignature => e
         render body: nil, status: :unauthorized
       end
     else
-      if current_user
-        session['user']=current_user
-      else
-        build_user_session("email" => 'guest', "groups" => ['world'])
-      end
+      build_user("email" => 'guest', "groups" => ['world'])
     end
   end  
 end

--- a/lib/jwt_credentials.rb
+++ b/lib/jwt_credentials.rb
@@ -6,7 +6,6 @@ module JWTCredentials
 
   def self.included(base)
     base.instance_eval do |klass|
-      #include JWTCredentials:Checks
       before_action :check_credentials
       before_action :apply_credentials
     end
@@ -20,17 +19,14 @@ module JWTCredentials
   end
 
   def build_user_session(hash)
-    #debugger    
     if defined? User
       session['user'] = User.from_jwt_data(hash)
-      #session['user'] = User.new(hash)
     else
       session['user'] = OpenStruct.new(hash)
     end    
   end
 
   def check_credentials
-    #debugger
     if request.headers.to_h['HTTP_X_AUTHORISATION']
       begin
         secret_key = Rails.configuration.jwt_secret_key
@@ -38,15 +34,6 @@ module JWTCredentials
         payload, header = JWT.decode token, secret_key, true, { algorithm: 'HS256'}
         ud = payload["data"]
         build_user_session(ud)
-        #if defined? User
-        #  session['user'] = User.new(ud['user'])
-        #else
-        #  session['user'] = OpenStruct.new(ud['user'])
-        #end
-        #session["user"] = {
-        #  "user" => ud["user"], #User.find_or_create_by(email: ud["user"]["email"]),
-        #  "groups" => ["world"]#ud["groups"].join(',') #ud["groups"].map { |name| Group.find_or_create_by(name: name) },
-        #}
 
       rescue JWT::VerificationError => e
         render body: nil, status: :unauthorized

--- a/lib/jwt_credentials.rb
+++ b/lib/jwt_credentials.rb
@@ -11,6 +11,16 @@ module JWTCredentials
     end
   end
 
+  attr_reader :x_auth_user
+
+  def current_user
+    if respond_to?(:auth_user)
+      auth_user || x_auth_user
+    else
+      x_auth_user
+    end
+  end
+
   def apply_credentials
     RequestStore.store[:x_authorisation] = current_user
   end
@@ -21,12 +31,6 @@ module JWTCredentials
     else
       @x_auth_user = OpenStruct.new(hash)
     end
-  end
-
-  # Override this for cases where the user credentials come from elsewhere,
-  #  e.g. a login session
-  def current_user
-    @x_auth_user
   end
 
   def check_credentials

--- a/lib/jwt_credentials.rb
+++ b/lib/jwt_credentials.rb
@@ -111,7 +111,7 @@ module JWTCredentials
   end
 
   def auth_service_url
-    "http://localhost:4321"
+    Rails.configuration.auth_service_url
   end
 
 end

--- a/lib/jwt_credentials.rb
+++ b/lib/jwt_credentials.rb
@@ -56,7 +56,6 @@ module JWTCredentials
         # Then delete their cookies
         cookies.delete :aker_auth_session
         cookies.delete :aker_user_jwt
-        # TODO: expire their session in the database
         redirect_to login_url
       rescue JWT::ExpiredSignature => e
         request_jwt

--- a/lib/jwt_credentials.rb
+++ b/lib/jwt_credentials.rb
@@ -79,7 +79,7 @@ module JWTCredentials
     conn = Faraday.new(url: 'http://localhost:4321')
     response = conn.post do |req|
       req.url '/renew_jwt'
-      req.body = JSON.generate({ email: cookies.encrypted[:aker_auth_session]['email'], groups: cookies.encrypted[:aker_auth_session]['groups'] })
+      req.body = cookies.encrypted[:aker_auth_session]['email']
     end
     # Update the JWT Cookie to contain the new JWT
     if response.body.present?

--- a/lib/jwt_serializer.rb
+++ b/lib/jwt_serializer.rb
@@ -6,8 +6,13 @@ class JWTSerializer < Faraday::Middleware
 
   def call(env)
     #debugger
-    token = JWTSerializer.generate_jwt(RequestStore.store[:x_authorisation])
-    env[:request_headers]["X-Authorisation"] = token
+    user_info = RequestStore.store[:x_authorisation]
+    if user_info
+      token = JWTSerializer.generate_jwt(user_info)
+      env[:request_headers]["X-Authorisation"] = token
+    else
+      env[:request_headers].delete("X-Authorisation")
+    end
     @app.call(env)
   end
 

--- a/lib/jwt_serializer.rb
+++ b/lib/jwt_serializer.rb
@@ -1,5 +1,6 @@
 require 'jwt'
 require 'request_store'
+require 'ostruct'
 
 class JWTSerializer < Faraday::Middleware
 
@@ -12,7 +13,9 @@ class JWTSerializer < Faraday::Middleware
 
   def self.generate_jwt(auth_hash)
     #debugger
-    unless auth_hash.is_a? Hash
+    if auth_hash.is_a? OpenStruct
+      auth_hash = auth_hash.to_h
+    elsif !auth_hash.is_a? Hash
       auth_hash = auth_hash.to_jwt_data
     end
     secret_key = Rails.application.config.jwt_secret_key

--- a/spec/aker_credentials_gem_spec.rb
+++ b/spec/aker_credentials_gem_spec.rb
@@ -1,11 +1,96 @@
-require "spec_helper"
+require 'spec_helper'
+require 'active_support/time'
+require 'faraday'
 
 RSpec.describe AkerCredentialsGem do
-  it "has a version number" do
-    expect(AkerCredentialsGem::VERSION).not_to be nil
+  let(:rails) { double('Rails') }
+
+  let(:credentials_class) do
+     class Credentials_Class
+       def self.before_action(symbol)
+       end
+       def Rails
+         rails
+       end
+       include JWTCredentials
+     end
   end
 
-  it "does something useful" do
-    expect(false).to eq(true)
+  before(:all) do
+    @secret_key = "top_secret"
+    @user_hash = {"email"=>"test@sanger.ac.uk", "groups"=>["world"]}
+
+    iat = Time.now.to_i
+    exp = Time.now.to_i + 3600
+    nbf = Time.now.to_i - 5
+
+    valid_data = { data: @user_hash,
+                   exp: exp,
+                   nbf: nbf,
+                   iat: iat }
+
+    expired_data = { data: @user_hash,
+                     exp: (Time.now - 1.seconds),
+                     nbf: (Time.now - 35.seconds),
+                     iat: (Time.now - 30.seconds) }
+
+    @valid_jwt = JWT.encode valid_data, @secret_key, 'HS256'
+    @tampered_jwt = JWT.encode valid_data, "wrong_key", 'HS256'
+    @expired_jwt = JWT.encode expired_data, @secret_key, 'HS256'
   end
+
+  before(:each) do
+    @credentials_instance = credentials_class.new
+    request = double('request', headers: nil)
+    allow(@credentials_instance).to receive(:request).and_return(request)
+    allow(@credentials_instance).to receive(:secret_key).and_return(@secret_key)
+  end
+
+  it "requests a JWT to replace an expired one" do
+    cookies = {aker_user_jwt: @expired_jwt}
+    allow(@credentials_instance).to receive(:cookies).and_return(cookies)
+
+    # The following exception shows an attempt at sending a request to the auth service
+    expect {@credentials_instance.check_credentials}.to raise_exception(Faraday::ConnectionFailed)
+  end
+
+  it "doesn't generate a user from a tampered_jwt" do
+    cookies = {aker_user_jwt: @tampered_jwt}
+    allow(@credentials_instance).to receive(:cookies).and_return(cookies)
+
+    @credentials_instance.check_credentials
+  end
+
+  it "redirects a user with no JWT (or session) cookie to login" do
+    cookies = {}
+    allow(@credentials_instance).to receive(:cookies).and_return(cookies)
+    @credentials_instance.check_credentials
+  end
+
+  it "accepts a valid JWT" do
+    cookies = {aker_user_jwt: @valid_jwt}
+    allow(@credentials_instance).to receive(:cookies).and_return(cookies)
+
+    # Ensures the user respresented by @valid_jwt is returned
+    expect(@credentials_instance.check_credentials).to eq(OpenStruct.new(@user_hash))
+  end
+
+  context 'the thing' do
+    let(:logger) { double('Logger') }
+    before do
+      allow(rails).to receive(:logger).and_return(logger)
+      allow(logger).to receive(:warn)
+    end
+
+    it '...' do
+
+      ....
+
+      expect(logger).to have_received(:warn).with(...)
+
+    end
+  end
+
+
+
 end

--- a/spec/aker_credentials_gem_spec.rb
+++ b/spec/aker_credentials_gem_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe AkerCredentialsGem do
     log
   end
 
-  let(:config) { double('config', login_url: 'http://loginurl') }
+  let(:config) { double('config', login_url: 'http://loginurl', auth_service_url: 'http://authserviceurl') }
   let(:request) { double('request', headers: {}, ip: '1', original_url: 'http://originalurl') }
   let(:jwt_key) { 'top_secret' }
   let(:userhash) { {"email"=>"test@sanger.ac.uk", "groups"=>["world"] } }

--- a/spec/jwt_credentials_spec.rb
+++ b/spec/jwt_credentials_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'active_support/time'
 require 'faraday'
 
-RSpec.describe AkerCredentialsGem do
+RSpec.describe JWTCredentials do
   let(:rails) { double('Rails', logger: logger, configuration: config) }
   let(:logger) do
     log = double('Logger')

--- a/spec/jwt_credentials_spec.rb
+++ b/spec/jwt_credentials_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'active_support/time'
 require 'faraday'
 
 RSpec.describe JWTCredentials do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
-require "bundler/setup"
-require "aker_credentials_gem"
+require 'bundler/setup'
+require 'aker_credentials_gem'
+require 'byebug'
+require 'jwt'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Accepts a JWT in a cookie. If it gets an expired JWT, tries to renew it.
This relies on changes to the auth service.
It also relies on finding appropriate config in the rails application this is used in.